### PR TITLE
fix(PLT-000): use the release namespace for the ingress

### DIFF
--- a/charts/ciso-assistant-next/templates/ingress/ingress.yaml
+++ b/charts/ciso-assistant-next/templates/ingress/ingress.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "ciso-assistant.labels" (dict "context" .) | nindent 4 }}
 spec:

--- a/charts/ciso-assistant-next/templates/ingress/tls-secret.yaml
+++ b/charts/ciso-assistant-next/templates/ingress/tls-secret.yaml
@@ -2,9 +2,10 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "ciso-assistant.fullname" . }}-tls
+   name: {{ include "ciso-assistant.fullname" . }}-tls
   labels:
     {{- include "ciso-assistant.labels" (dict "context" . "component" "frontend") | nindent 4 }}
+  namespace: {{ .Release.Namespace }}
 type: kubernetes.io/tls
 data:
   tls.crt: {{ .Values.ingress.tls.certificateSecret.certificate | b64enc }}


### PR DESCRIPTION
Currently, doing a helm install of the chart spawns the ingress in the current namespace instead of the namespace of the release.
This PR fixes that.